### PR TITLE
Add spark-java-sdk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A notification plugin for Rundeck to send notifications to WebEx Teams.
 
+## Dependencies
+
+* [spark-java sdk](https://github.com/webex/spark-java-sdk)
+
 ## Installation instructions
 
 1. Build a snapshot from source using `gradle build`


### PR DESCRIPTION
In order to build this plugin I had to grab the spark-java-sdk and install it via maven. The instructions in that repo were sufficient to get `gradle build` for this project working.

This change adds spark-java-sdk (available at https://github.com/webex/spark-java-sdk) as a dependecy.